### PR TITLE
Add cleanlab to data quality list

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A curated list of awesome DataOps tools.
 * [Great Expectations](https://greatexpectations.io) - A Python data validation framework that allows to test your data against datasets.
 * [JSON Schema](https://json-schema.org/) - A vocabulary that allows you to annotate and validate JSON documents.
 * [SodaSQL](https://github.com/sodadata/soda-sql) - Data profiling, testing, and monitoring for SQL accessible data.
+* [cleanlab](https://github.com/cleanlab/cleanlab): Detect various issues in ML datasets like label errors and outliers, estimate consensus + annotator-quality for multi-annotator datasets, and decide what data is best to (re)label next.
 
 ## Data Serialization
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ A curated list of awesome DataOps tools.
 
 *Tools for ensuring data quality.*
 
+* [Cleanlab](https://github.com/cleanlab/cleanlab) - Data-centric AI tool to detect (non-predefined) issues in ML data like label errors or outliers.
 * [Cerberus](https://github.com/pyeve/cerberus) - Lightweight, extensible data validation library for Python.
 * [Deequ](https://github.com/awslabs/deequ) - A library built on top of Apache Spark for measuring data quality in large datasets.
 * [Great Expectations](https://greatexpectations.io) - A Python data validation framework that allows to test your data against datasets.
 * [JSON Schema](https://json-schema.org/) - A vocabulary that allows you to annotate and validate JSON documents.
 * [SodaSQL](https://github.com/sodadata/soda-sql) - Data profiling, testing, and monitoring for SQL accessible data.
-* [cleanlab](https://github.com/cleanlab/cleanlab): Detect various issues in ML datasets like label errors and outliers, estimate consensus + annotator-quality for multi-annotator datasets, and decide what data is best to (re)label next.
 
 ## Data Serialization
 


### PR DESCRIPTION
## What is this tool for?

cleanlab (4.4k github stars) is a data-centric AI package for data quality and machine learning with messy, real-world data and labels.
It is super easy to use (one line of code for many tasks) and can automatically detect various issues in ML datasets like label errors and outliers/out-of-distribution examples, as well as estimate consensus + annotator-quality for multi-annotator datasets, and decide what data is best to (re)label next (active learning).


## What's the difference between this tool and similar ones?

I am not aware of similar tools to cleanlab. Most semi-related tools focus on one type of data issue only (eg. outlier detection) and are often research-level code rather than production-grade libraries.

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
