### PR TITLE
Add Memgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A curated list of awesome DataOps tools.
 ### Graph Database
 
 * [ArangoDB](https://github.com/arangodb/arangodb) - A scalable open-source multi-model database natively supporting graph, document and search.
+* [Memgraph](https://github.com/memgraph/memgraph) - An open source graph database, built for real-time streaming data, compatible with Neo4j.
 * [Neo4j](https://github.com/neo4j/neo4j) - A high performance graph store with all the features expected of a mature and robust database.
 * [Titan](https://github.com/thinkaurelius/titan) - A highly scalable graph database optimized for storing and querying large graphs.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ A curated list of awesome DataOps tools.
 * [ArangoDB](https://github.com/arangodb/arangodb) - A scalable open-source multi-model database natively supporting graph, document and search.
 * [Neo4j](https://github.com/neo4j/neo4j) - A high performance graph store with all the features expected of a mature and robust database.
 * [Titan](https://github.com/thinkaurelius/titan) - A highly scalable graph database optimized for storing and querying large graphs.
-* [Memgraph](https://github.com/memgraph/memgraph) - An open source graph database, built for real-time streaming data, compatible with Neo4j.
 
 ### Key-Value Database
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A curated list of awesome DataOps tools.
 * [ArangoDB](https://github.com/arangodb/arangodb) - A scalable open-source multi-model database natively supporting graph, document and search.
 * [Neo4j](https://github.com/neo4j/neo4j) - A high performance graph store with all the features expected of a mature and robust database.
 * [Titan](https://github.com/thinkaurelius/titan) - A highly scalable graph database optimized for storing and querying large graphs.
+* [Memgraph](https://github.com/memgraph/memgraph) - An open source graph database, built for real-time streaming data, compatible with Neo4j.
 
 ### Key-Value Database
 


### PR DESCRIPTION
## What is this tool for?

- Memgraph is an open source graph database built for real-time streaming and compatible with Neo4j.
- Memgraph directly connects to your streaming infrastructure (Kafka, SQL, CSV). 
- Memgraph provides a standard interface to query your data with Cypher, a widely-used and declarative query language that is easy to write, understand and optimize for performance.

## What's the difference between this tool and similar ones?

What are the differences between Neo4j and Memgraph?

- Neo4j is written in Java, while Memgraph is written in C++
- Neo4j stores data on-disk, while Memgraph is an in-memory database that focuses on stream data processing and real-time computations, aiming to execute tasks within the shortest possible timeframe
- Custom procedures in Neo4j should be implemented using Java, while Memgraph is primarily focused on the Python ecosystem
- Native support for machine learning

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
