### PR TITLE
Add CsvPath Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A curated list of awesome DataOps tools.
 * [Nakadi](https://github.com/zalando/nakadi) - A distributed event bus that implements a RESTful API abstraction on top of Kafka-like queues.
 * [Pravega](https://github.com/pravega/pravega) - An open source distributed storage service implementing Streams.
 * [RabbitMQ](https://www.rabbitmq.com/) - One of the most popular open source message brokers.
+* [CsvPath Framework](https://www.csvpath.org/) - Fills the preboarding gap between MFT and the data lake for delimited data files.
 
 ## Data Workflow
 


### PR DESCRIPTION
Added CsvPath Framework to the data ingestion tools with a link to csvpath.org.

David

## What is this tool for?

Bringing CVS, Excel, data frames and other delimited files into the organization in a more controlled way. It adds durable identification, enables validation and data upgrading/canonicalization, and stages data for import into the data lake from an immutable archive. CsvPath Framework is pre-integrated with OpenTelemetry and OpenLineage for observability and tracing.

## What's the difference between this tool and similar ones?

There are no known open source or commercial products that take a similar approach to automated delimited data preboarding built to scale to any number of data partners. For user self-service delimited file uploading there is FlatFile and OneSchema. The Frictionless Framework + CKAN provide validated publishing of delimited file datasets which is adjacent to preboarding if publishing within the enterprise. (CsvPath Framework is also pre-integrated with CKAN, but taking a different more-DataOps infrastructure approach and volume focus).

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
