### PR TITLE
Add Marimo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A curated list of awesome DataOps tools.
 * [Jupyter Notebook](https://jupyter.org/) - Web-based notebook environment for interactive computing.
 * [JupyterLab](https://jupyterlab.readthedocs.io) - The next-generation user interface for Project Jupyter.
 * [Jupytext](https://github.com/mwouts/jupytext) - Jupyter Notebooks as Markdown Documents, Julia, Python or R scripts.
+* [Marimo](https://github.com/marimo-team/marimo) - A reactive Python notebook that's reproducible, git-friendly, and deployable as scripts or apps.
 * [Polynote](https://polynote.org/) - The polyglot notebook with first-class Scala support.
 
 ## Data Ingestion


### PR DESCRIPTION
## What is this tool for?

Marimo is a reactive Python notebook that syncs cells via a static dataflow graph, stores notebooks as clean `.py` files, and supports UI widgets, SQL, AI assistants, and app deployment.

## What's the difference between this tool and similar ones?

- Jupyter Notebook is JSON-based, whereas Marimo uses pure Python files, making it more Git-friendly.

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
